### PR TITLE
Changed part concerning older versions of Java

### DIFF
--- a/roles/apps/tasks/main.yml
+++ b/roles/apps/tasks/main.yml
@@ -15,7 +15,7 @@
   with_items:
     # for maven
     - java
-    - adoptopenjdk8
+    - adoptopenjdk11
 
 - name: install brews
   homebrew: name={{ item }} state=present

--- a/roles/apps/tasks/main.yml
+++ b/roles/apps/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: install taps
   homebrew_tap: tap={{ item }} state=present
   with_items:
-    - caskroom/cask
+    - homebrew/cask
     - argon/mas
     - cloudfoundry/tap
     # for older java versions
-    - caskroom/versions
+    - homebrew/cask-versions
 
 - name: install prerequisite casks
   homebrew_cask: name={{ item }} state=present
@@ -15,7 +15,7 @@
   with_items:
     # for maven
     - java
-    - java8
+    - adoptopenjdk8
 
 - name: install brews
   homebrew: name={{ item }} state=present


### PR DESCRIPTION
Installing java8 is not possible with cask (java8 cask is no longer available). Instead, we need to use adoptopenjdk8
See this for details: https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac 