### PR TITLE
Feature/remove java installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Thumbs.db
 
 /Optometrist.terminal
 /host_vars/localhost.yml
+
+.idea

--- a/roles/apps/tasks/main.yml
+++ b/roles/apps/tasks/main.yml
@@ -5,17 +5,6 @@
     - caskroom/cask
     - argon/mas
     - cloudfoundry/tap
-    # for older java versions
-    - caskroom/versions
-
-- name: install prerequisite casks
-  homebrew_cask: name={{ item }} state=present
-  when: not lookup("env", "CI")
-  ignore_errors: yes
-  with_items:
-    # for maven
-    - java
-    - java8
 
 - name: install brews
   homebrew: name={{ item }} state=present
@@ -78,7 +67,6 @@
     - docker
     - google-chrome
     - firefox
-    - java
     - kaleidoscope
     - libreoffice
     - paparazzi


### PR DESCRIPTION
### Important changes
Removed commands that install `Java`. We will have detailed instructions on how to install `Java` as part of the [Java page in the CTO space](https://3apjira.atlassian.net/wiki/spaces/CTO/pages/1348239388/Java+JDK).